### PR TITLE
Add missing breaks in switch

### DIFF
--- a/src/platforms/jeff/usbdfu.c
+++ b/src/platforms/jeff/usbdfu.c
@@ -175,11 +175,13 @@ static void usbdfu_getstatus_complete(usbd_device *usbd_dev, struct usb_setup_da
 					uint32_t *dat = (uint32_t *)(prog.buf + 1);
 					nvmctrl_erase_row(*dat); //flash_erase_page(*dat);
 				}
+				break;
 			case CMD_SETADDR:
 				{
 					uint32_t *dat = (uint32_t *)(prog.buf + 1);
 					prog.addr = *dat;
 				}
+				break;
 			}
 		} else {
 			//uint32_t baseaddr = prog.addr + ((prog.blocknum - 2) *


### PR DESCRIPTION
Accidental fall-through was reported by gcc 9.2.1.
